### PR TITLE
TWEAK: handle json invalid payload in discard middleware

### DIFF
--- a/job.go
+++ b/job.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,12 +34,22 @@ type Job struct {
 
 // UnmarshalPayload decodes the msgpack payload into a variable.
 func (j *Job) UnmarshalPayload(v interface{}) error {
-	return unmarshal(bytes.NewReader(j.Payload), v)
+	// used in middleware/discard package.
+	err := unmarshal(bytes.NewReader(j.Payload), v)
+	if err != nil {
+		return fmt.Errorf("work: invalid job payload: %s", err)
+	}
+	return nil
 }
 
 // UnmarshalJSONPayload decodes the JSON payload into a variable.
 func (j *Job) UnmarshalJSONPayload(v interface{}) error {
-	return json.Unmarshal(j.Payload, v)
+	// used in middleware/discard package.
+	err := json.Unmarshal(j.Payload, v)
+	if err != nil {
+		return fmt.Errorf("work: invalid job payload: %s", err)
+	}
+	return nil
 }
 
 // MarshalPayload encodes a variable into the msgpack payload.

--- a/middleware/discard/invalid_payload.go
+++ b/middleware/discard/invalid_payload.go
@@ -13,7 +13,7 @@ func InvalidPayload(f work.HandleFunc) work.HandleFunc {
 		err := f(job, opt)
 		if err != nil {
 			cerr := errors.Cause(err)
-			if strings.HasPrefix(cerr.Error(), "msgpack:") {
+			if strings.HasPrefix(cerr.Error(), "work: invalid job payload: ") {
 				return work.ErrUnrecoverable
 			}
 			return err

--- a/middleware/discard/invalid_payload_test.go
+++ b/middleware/discard/invalid_payload_test.go
@@ -1,7 +1,6 @@
 package discard
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +14,8 @@ func TestInvalidPayload(t *testing.T) {
 		QueueID:   "q1",
 	}
 	h := InvalidPayload(func(*work.Job, *work.DequeueOptions) error {
-		return errors.New("msgpack: decode")
+		var s string
+		return job.UnmarshalPayload(&s)
 	})
 
 	err := h(job, opt)


### PR DESCRIPTION
go1.13 has better error support but we are not using that now.