### PR TITLE
FEATURE: more efficient sidekiq pull

### DIFF
--- a/sidekiq/pull.go
+++ b/sidekiq/pull.go
@@ -1,0 +1,162 @@
+package sidekiq
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/taylorchu/work"
+)
+
+// JobPuller pulls jobs from sidekiq-compatible queue.
+type JobPuller interface {
+	Pull(*PullOptions) error
+}
+
+// PullOptions specifies how a job is pulled from sidekiq-compatible queue.
+type PullOptions struct {
+	// work-compatible namespace
+	Namespace string
+	// optional work-compatible queue
+	// This allows moving jobs to another redis instance. Without this, these jobs are moved
+	// within the same sidekiq redis instance.
+	Queue work.Queue
+	// sidekiq-compatible namespace
+	// Only used by https://github.com/resque/redis-namespace. By default, it is empty.
+	SidekiqNamespace string
+	// sidekiq-compatible queue like `default`.
+	SidekiqQueue string
+}
+
+// Validate validates PullOptions.
+func (opt *PullOptions) Validate() error {
+	if opt.Namespace == "" {
+		return work.ErrEmptyNamespace
+	}
+	if opt.SidekiqQueue == "" {
+		return work.ErrEmptyQueueID
+	}
+	return nil
+}
+
+// Pull moves jobs from sidekiq-compatible queue into work-compatible queue.
+func (q *sidekiqQueue) Pull(opt *PullOptions) error {
+	err := opt.Validate()
+	if err != nil {
+		return err
+	}
+	queueNamespace := fmt.Sprintf("%s:sidekiq-queue-pull:%s", opt.SidekiqNamespace, opt.SidekiqQueue)
+	queueID := uuid.NewString()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	expireInSec := 10
+	err = q.dequeueStartScript.Run(ctx, q.client, nil,
+		opt.SidekiqNamespace,
+		opt.SidekiqQueue,
+		queueNamespace,
+		queueID,
+		time.Now().Unix(),
+		expireInSec,
+	).Err()
+	if err != nil {
+		return err
+	}
+	defer func() error {
+		return q.dequeueStopScript.Run(ctx, q.client, nil,
+			queueNamespace,
+			queueID,
+		).Err()
+	}()
+	go func() {
+		defer cancel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+				err := q.dequeueHeartbeatScript.Run(ctx, q.client, nil,
+					queueNamespace,
+					queueID,
+					time.Now().Unix(),
+					expireInSec,
+				).Err()
+				if err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	pull := func() error {
+		res, err := q.dequeueScript.Run(ctx, q.client, nil,
+			queueNamespace,
+			queueID,
+		).Result()
+		if err != nil {
+			return err
+		}
+		var sqJob sidekiqJob
+		err = json.NewDecoder(strings.NewReader(res.(string))).Decode(&sqJob)
+		if err != nil {
+			return err
+		}
+		err = sqJob.Validate()
+		if err != nil {
+			return err
+		}
+		job, err := newJob(&sqJob)
+		if err != nil {
+			return err
+		}
+		queue := opt.Queue
+		if queue == nil {
+			queue = q.RedisQueue
+		}
+		var found bool
+		if finder, ok := queue.(work.BulkJobFinder); ok {
+			// best effort to check for duplicates
+			jobs, err := finder.BulkFind([]string{job.ID}, &work.FindOptions{
+				Namespace: opt.Namespace,
+			})
+			if err != nil {
+				return err
+			}
+			found = len(jobs) == 1 && jobs[0] != nil
+		}
+		if !found {
+			err := queue.Enqueue(job, &work.EnqueueOptions{
+				Namespace: opt.Namespace,
+				QueueID:   FormatQueueID(sqJob.Queue, sqJob.Class),
+			})
+			if err != nil {
+				return err
+			}
+		}
+		err = q.ackScript.Run(ctx, q.client, nil,
+			queueNamespace,
+			queueID,
+			res.(string),
+		).Err()
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	for {
+		err := pull()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/sidekiq/pull.go
+++ b/sidekiq/pull.go
@@ -57,6 +57,7 @@ func (q *sidekiqQueue) Pull(opt *PullOptions) error {
 	defer cancel()
 
 	expireInSec := 10
+	refreshInSec := 2
 	err = q.dequeueStartScript.Run(ctx, q.client, nil,
 		opt.SidekiqNamespace,
 		opt.SidekiqQueue,
@@ -80,7 +81,7 @@ func (q *sidekiqQueue) Pull(opt *PullOptions) error {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(time.Second):
+			case <-time.After(time.Duration(refreshInSec) * time.Second):
 				err := q.dequeueHeartbeatScript.Run(ctx, q.client, nil,
 					queueNamespace,
 					queueID,

--- a/sidekiq/pull_test.go
+++ b/sidekiq/pull_test.go
@@ -17,6 +17,7 @@ func TestPullDequeueStartEmpty(t *testing.T) {
 
 	q := NewQueue(client)
 	now := time.Now()
+
 	err := q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
 		"default",
@@ -46,6 +47,7 @@ func TestPullDequeueStartNormal(t *testing.T) {
 
 	q := NewQueue(client)
 	now := time.Now()
+
 	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
 		"default",
@@ -91,6 +93,7 @@ func TestPullDequeueStartAlreadyStarted(t *testing.T) {
 
 	q := NewQueue(client)
 	now := time.Now()
+
 	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
 		"default",
@@ -144,6 +147,7 @@ func TestPullDequeueStartRecoveredNotExpired(t *testing.T) {
 
 	q := NewQueue(client)
 	now := time.Now()
+
 	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
 		"default",
@@ -232,6 +236,7 @@ func TestPullDequeueStartRecoveredExpired(t *testing.T) {
 
 	q := NewQueue(client)
 	now := time.Now()
+
 	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
 		"default",
@@ -311,7 +316,15 @@ func TestPullDequeueStop(t *testing.T) {
 
 	q := NewQueue(client)
 	now := time.Now()
-	err := q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+
+	// no error without pullers key
+	err := q.(*sidekiqQueue).dequeueStopScript.Run(context.Background(), client, nil,
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+	).Err()
+	require.NoError(t, err)
+
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
 		"default",
 		"{sidekiq}:sidekiq-queue-pull:default",
@@ -333,6 +346,7 @@ func TestPullDequeueStop(t *testing.T) {
 	require.Equal(t, "123", z[0].Member)
 	require.EqualValues(t, now.Unix()+10, z[0].Score)
 
+	// remove existing entries
 	err = q.(*sidekiqQueue).dequeueStopScript.Run(context.Background(), client, nil,
 		"{sidekiq}:sidekiq-queue-pull:default",
 		"123",
@@ -357,7 +371,17 @@ func TestPullDequeueHeartbeat(t *testing.T) {
 
 	q := NewQueue(client)
 	now := time.Now()
-	err := q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+
+	// no error without pullers key
+	err := q.(*sidekiqQueue).dequeueHeartbeatScript.Run(context.Background(), client, nil,
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		100,
+	).Err()
+	require.NoError(t, err)
+
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
 		"default",
 		"{sidekiq}:sidekiq-queue-pull:default",
@@ -379,6 +403,7 @@ func TestPullDequeueHeartbeat(t *testing.T) {
 	require.Equal(t, "123", z[0].Member)
 	require.EqualValues(t, now.Unix()+10, z[0].Score)
 
+	// extend expiration
 	err = q.(*sidekiqQueue).dequeueHeartbeatScript.Run(context.Background(), client, nil,
 		"{sidekiq}:sidekiq-queue-pull:default",
 		"123",
@@ -399,6 +424,7 @@ func TestPullDequeueHeartbeat(t *testing.T) {
 	require.Equal(t, "123", z[0].Member)
 	require.EqualValues(t, now.Unix()+100, z[0].Score)
 
+	// test invalid entries
 	err = q.(*sidekiqQueue).dequeueHeartbeatScript.Run(context.Background(), client, nil,
 		"{sidekiq}:sidekiq-queue-pull:default",
 		"456",

--- a/sidekiq/pull_test.go
+++ b/sidekiq/pull_test.go
@@ -154,12 +154,9 @@ func TestPullDequeueStartRecoveredNotExpired(t *testing.T) {
 	).Err()
 	require.NoError(t, err)
 
-	err = client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
-	require.NoError(t, err)
-
 	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
 	require.NoError(t, err)
-	require.Equal(t, int64(1), count)
+	require.Equal(t, int64(0), count)
 
 	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
 	require.NoError(t, err)
@@ -176,6 +173,13 @@ func TestPullDequeueStartRecoveredNotExpired(t *testing.T) {
 	require.Len(t, z, 1)
 	require.Equal(t, "123", z[0].Member)
 	require.EqualValues(t, now.Unix()+10, z[0].Score)
+
+	err = client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
 
 	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
@@ -238,12 +242,9 @@ func TestPullDequeueStartRecoveredExpired(t *testing.T) {
 	).Err()
 	require.NoError(t, err)
 
-	err = client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
-	require.NoError(t, err)
-
 	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
 	require.NoError(t, err)
-	require.Equal(t, int64(1), count)
+	require.Equal(t, int64(0), count)
 
 	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
 	require.NoError(t, err)
@@ -260,6 +261,13 @@ func TestPullDequeueStartRecoveredExpired(t *testing.T) {
 	require.Len(t, z, 1)
 	require.Equal(t, "123", z[0].Member)
 	require.EqualValues(t, now.Unix()+10, z[0].Score)
+
+	err = client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
 
 	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
 		"{sidekiq}",
@@ -342,7 +350,7 @@ func TestPullDequeueStop(t *testing.T) {
 	require.Len(t, z, 0)
 }
 
-func TestPullDequeueHeartbeatNormal(t *testing.T) {
+func TestPullDequeueHeartbeat(t *testing.T) {
 	client := redistest.NewClient()
 	defer client.Close()
 	require.NoError(t, redistest.Reset(client))

--- a/sidekiq/pull_test.go
+++ b/sidekiq/pull_test.go
@@ -1,0 +1,413 @@
+package sidekiq
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"github.com/taylorchu/work/redistest"
+)
+
+func TestPullDequeueStartEmpty(t *testing.T) {
+	client := redistest.NewClient()
+	defer client.Close()
+	require.NoError(t, redistest.Reset(client))
+
+	q := NewQueue(client)
+	now := time.Now()
+	err := q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	count, err := client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+}
+
+func TestPullDequeueStartNormal(t *testing.T) {
+	client := redistest.NewClient()
+	defer client.Close()
+	require.NoError(t, redistest.Reset(client))
+
+	err := client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err := client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	q := NewQueue(client)
+	now := time.Now()
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	z, err := client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+10, z[0].Score)
+}
+
+func TestPullDequeueStartAlreadyStarted(t *testing.T) {
+	client := redistest.NewClient()
+	defer client.Close()
+	require.NoError(t, redistest.Reset(client))
+
+	err := client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err := client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	q := NewQueue(client)
+	now := time.Now()
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	err = client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+func TestPullDequeueStartRecoveredNotExpired(t *testing.T) {
+	client := redistest.NewClient()
+	defer client.Close()
+	require.NoError(t, redistest.Reset(client))
+
+	err := client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err := client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	q := NewQueue(client)
+	now := time.Now()
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	err = client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	z, err := client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+10, z[0].Score)
+
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"456",
+		now.Unix()+1,
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:456").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	z, err = client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 2)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+10, z[0].Score)
+	require.Equal(t, "456", z[1].Member)
+	require.EqualValues(t, now.Unix()+11, z[1].Score)
+}
+
+func TestPullDequeueStartRecoveredExpired(t *testing.T) {
+	client := redistest.NewClient()
+	defer client.Close()
+	require.NoError(t, redistest.Reset(client))
+
+	err := client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err := client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	q := NewQueue(client)
+	now := time.Now()
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	err = client.LPush(context.Background(), "{sidekiq}:queue:default", `{"class":"TestWorker","args":[],"retry":3,"queue":"default","backtrace":true,"jid":"83b27ea26dd65821239ca6aa","created_at":1567788641.0875323,"enqueued_at":1567788642.0879307,"retry_count":2,"error_message":"error: test","error_class":"StandardError","failed_at":1567791043,"retried_at":1567791046}"`).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	z, err := client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+10, z[0].Score)
+
+	err = q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"456",
+		now.Unix()+30,
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:queue:default").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:123").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+
+	count, err = client.Exists(context.Background(), "{sidekiq}:sidekiq-queue-pull:default:456").Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+
+	z, err = client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "456", z[0].Member)
+	require.EqualValues(t, now.Unix()+40, z[0].Score)
+}
+
+func TestPullDequeueStop(t *testing.T) {
+	client := redistest.NewClient()
+	defer client.Close()
+	require.NoError(t, redistest.Reset(client))
+
+	q := NewQueue(client)
+	now := time.Now()
+	err := q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	z, err := client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+10, z[0].Score)
+
+	err = q.(*sidekiqQueue).dequeueStopScript.Run(context.Background(), client, nil,
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+	).Err()
+	require.NoError(t, err)
+
+	z, err = client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 0)
+}
+
+func TestPullDequeueHeartbeatNormal(t *testing.T) {
+	client := redistest.NewClient()
+	defer client.Close()
+	require.NoError(t, redistest.Reset(client))
+
+	q := NewQueue(client)
+	now := time.Now()
+	err := q.(*sidekiqQueue).dequeueStartScript.Run(context.Background(), client, nil,
+		"{sidekiq}",
+		"default",
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		10,
+	).Err()
+	require.NoError(t, err)
+
+	z, err := client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+10, z[0].Score)
+
+	err = q.(*sidekiqQueue).dequeueHeartbeatScript.Run(context.Background(), client, nil,
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"123",
+		now.Unix(),
+		100,
+	).Err()
+	require.NoError(t, err)
+
+	z, err = client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+100, z[0].Score)
+
+	err = q.(*sidekiqQueue).dequeueHeartbeatScript.Run(context.Background(), client, nil,
+		"{sidekiq}:sidekiq-queue-pull:default",
+		"456",
+		now.Unix(),
+		100,
+	).Err()
+	require.NoError(t, err)
+
+	z, err = client.ZRangeByScoreWithScores(
+		context.Background(),
+		"{sidekiq}:sidekiq-queue-pull:default:pullers",
+		&redis.ZRangeBy{
+			Min: "-inf",
+			Max: "+inf",
+		}).Result()
+	require.NoError(t, err)
+	require.Len(t, z, 1)
+	require.Equal(t, "123", z[0].Member)
+	require.EqualValues(t, now.Unix()+100, z[0].Score)
+}

--- a/sidekiq/queue.go
+++ b/sidekiq/queue.go
@@ -231,7 +231,7 @@ func (q *sidekiqQueue) Pull(opt *PullOptions) error {
 	if err != nil {
 		return err
 	}
-	queueNamespace := "{sidekiq-queue-pull}"
+	queueNamespace := fmt.Sprintf("%s:sidekiq-queue-pull:%s", opt.SidekiqNamespace, opt.SidekiqQueue)
 	queueID := uuid.NewString()
 	err = q.dequeueRenameScript.Run(context.Background(), q.client, nil,
 		opt.SidekiqNamespace,

--- a/sidekiq/queue.go
+++ b/sidekiq/queue.go
@@ -231,7 +231,7 @@ func (q *sidekiqQueue) Pull(opt *PullOptions) error {
 	if err != nil {
 		return err
 	}
-	queueNamespace := fmt.Sprintf("%s:sidekiq-queue-pull:%s", opt.SidekiqNamespace, opt.SidekiqQueue)
+	queueNamespace := fmt.Sprintf("sidekiq-queue-pull:%s:%s", opt.SidekiqNamespace, opt.SidekiqQueue)
 	queueID := uuid.NewString()
 	err = q.dequeueRenameScript.Run(context.Background(), q.client, nil,
 		opt.SidekiqNamespace,

--- a/sidekiq/queue.go
+++ b/sidekiq/queue.go
@@ -2,13 +2,11 @@ package sidekiq
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/taylorchu/work"
 )
@@ -132,11 +130,15 @@ func NewQueue(client redis.UniversalClient) Queue {
 	local old_queue_ids = redis.call("zrangebyscore", pullers_key, "-inf", at, "limit", 0, 1)
 	for i, old_queue_id in pairs(old_queue_ids) do
 		local old_puller_queue_key = table.concat({queue_ns, old_queue_id}, ":")
-		redis.call("rename", old_puller_queue_key, puller_queue_key)
+		if redis.call("exists", old_puller_queue_key) == 1 then
+			redis.call("rename", old_puller_queue_key, puller_queue_key)
+		end
 		redis.call("zrem", pullers_key, old_queue_id)
 		return 1
 	end
-	redis.call("rename", queue_key, puller_queue_key)
+	if redis.call("exists", queue_key) == 1 then
+		redis.call("rename", queue_key, puller_queue_key)
+	end
 	return 1
 	`)
 
@@ -222,152 +224,4 @@ func FormatQueueID(queue, class string) string {
 
 func (q *sidekiqQueue) schedule(ns string, at time.Time) error {
 	return q.scheduleScript.Run(context.Background(), q.client, nil, ns, at.Unix()).Err()
-}
-
-// JobPuller pulls jobs from sidekiq-compatible queue.
-type JobPuller interface {
-	Pull(*PullOptions) error
-}
-
-// PullOptions specifies how a job is pulled from sidekiq-compatible queue.
-type PullOptions struct {
-	// work-compatible namespace
-	Namespace string
-	// optional work-compatible queue
-	// This allows moving jobs to another redis instance. Without this, these jobs are moved
-	// within the same sidekiq redis instance.
-	Queue work.Queue
-	// sidekiq-compatible namespace
-	// Only used by https://github.com/resque/redis-namespace. By default, it is empty.
-	SidekiqNamespace string
-	// sidekiq-compatible queue like `default`.
-	SidekiqQueue string
-}
-
-// Validate validates PullOptions.
-func (opt *PullOptions) Validate() error {
-	if opt.Namespace == "" {
-		return work.ErrEmptyNamespace
-	}
-	if opt.SidekiqQueue == "" {
-		return work.ErrEmptyQueueID
-	}
-	return nil
-}
-
-// Pull moves jobs from sidekiq-compatible queue into work-compatible queue.
-func (q *sidekiqQueue) Pull(opt *PullOptions) error {
-	err := opt.Validate()
-	if err != nil {
-		return err
-	}
-	queueNamespace := fmt.Sprintf("%s:sidekiq-queue-pull:%s", opt.SidekiqNamespace, opt.SidekiqQueue)
-	queueID := uuid.NewString()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	expireInSec := 10
-	err = q.dequeueStartScript.Run(ctx, q.client, nil,
-		opt.SidekiqNamespace,
-		opt.SidekiqQueue,
-		queueNamespace,
-		queueID,
-		time.Now().Unix(),
-		expireInSec,
-	).Err()
-	if err != nil {
-		return err
-	}
-	defer func() error {
-		return q.dequeueStopScript.Run(ctx, q.client, nil,
-			queueNamespace,
-			queueID,
-		).Err()
-	}()
-	go func() {
-		defer cancel()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-time.After(time.Second):
-				err := q.dequeueHeartbeatScript.Run(ctx, q.client, nil,
-					queueNamespace,
-					queueID,
-					time.Now().Unix(),
-					expireInSec,
-				).Err()
-				if err != nil {
-					return
-				}
-			}
-		}
-	}()
-
-	pull := func() error {
-		res, err := q.dequeueScript.Run(ctx, q.client, nil,
-			queueNamespace,
-			queueID,
-		).Result()
-		if err != nil {
-			return err
-		}
-		var sqJob sidekiqJob
-		err = json.NewDecoder(strings.NewReader(res.(string))).Decode(&sqJob)
-		if err != nil {
-			return err
-		}
-		err = sqJob.Validate()
-		if err != nil {
-			return err
-		}
-		job, err := newJob(&sqJob)
-		if err != nil {
-			return err
-		}
-		queue := opt.Queue
-		if queue == nil {
-			queue = q.RedisQueue
-		}
-		var found bool
-		if finder, ok := queue.(work.BulkJobFinder); ok {
-			// best effort to check for duplicates
-			jobs, err := finder.BulkFind([]string{job.ID}, &work.FindOptions{
-				Namespace: opt.Namespace,
-			})
-			if err != nil {
-				return err
-			}
-			found = len(jobs) == 1 && jobs[0] != nil
-		}
-		if !found {
-			err := queue.Enqueue(job, &work.EnqueueOptions{
-				Namespace: opt.Namespace,
-				QueueID:   FormatQueueID(sqJob.Queue, sqJob.Class),
-			})
-			if err != nil {
-				return err
-			}
-		}
-		err = q.ackScript.Run(ctx, q.client, nil,
-			queueNamespace,
-			queueID,
-			res.(string),
-		).Err()
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	for {
-		err := pull()
-		if err != nil {
-			if errors.Is(err, redis.Nil) {
-				return nil
-			}
-			return err
-		}
-	}
 }

--- a/sidekiq/queue.go
+++ b/sidekiq/queue.go
@@ -118,10 +118,6 @@ func NewQueue(client redis.UniversalClient) Queue {
 	local at = tonumber(ARGV[5])
 	local expire_in_sec = tonumber(ARGV[6])
 
-	local queue_key = table.concat({"queue", sidekiq_queue}, ":")
-	if sidekiq_ns ~= "" then
-		queue_key = table.concat({sidekiq_ns, queue_key}, ":")
-	end
 	local pullers_key = table.concat({queue_ns, "pullers"}, ":")
 	if redis.call("zadd", pullers_key, "nx", at + expire_in_sec, queue_id) == 0 then
 		return 0
@@ -135,6 +131,11 @@ func NewQueue(client redis.UniversalClient) Queue {
 		end
 		redis.call("zrem", pullers_key, old_queue_id)
 		return 1
+	end
+
+	local queue_key = table.concat({"queue", sidekiq_queue}, ":")
+	if sidekiq_ns ~= "" then
+		queue_key = table.concat({sidekiq_ns, queue_key}, ":")
 	end
 	if redis.call("exists", queue_key) == 1 then
 		redis.call("rename", queue_key, puller_queue_key)

--- a/sidekiq/queue.go
+++ b/sidekiq/queue.go
@@ -231,7 +231,7 @@ func (q *sidekiqQueue) Pull(opt *PullOptions) error {
 	if err != nil {
 		return err
 	}
-	queueNamespace := "sidekiq-queue-pull"
+	queueNamespace := "{sidekiq-queue-pull}"
 	queueID := uuid.NewString()
 	err = q.dequeueRenameScript.Run(context.Background(), q.client, nil,
 		opt.SidekiqNamespace,

--- a/sidekiq/queue_test.go
+++ b/sidekiq/queue_test.go
@@ -7,11 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 	"github.com/taylorchu/work"
-	"github.com/taylorchu/work/redislock"
 	"github.com/taylorchu/work/redistest"
 	"github.com/vmihailenco/msgpack/v5"
 )
@@ -272,47 +270,6 @@ func TestSidekiqQueueDequeue(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, work.ErrEmptyQueue, err)
-}
-
-func TestSidekiqQueueDequeueLocked(t *testing.T) {
-	client := redistest.NewClient()
-	defer client.Close()
-	require.NoError(t, redistest.Reset(client))
-	q := NewQueue(client)
-
-	job := work.NewJob()
-	err := job.MarshalJSONPayload([]int{1, 2, 3})
-	require.NoError(t, err)
-
-	err = q.ExternalEnqueue(job, &work.EnqueueOptions{
-		Namespace: "{ns1}",
-		QueueID:   "low/q1",
-	})
-	require.NoError(t, err)
-
-	now := job.EnqueuedAt.Add(123 * time.Second)
-
-	err = q.schedule("{ns1}", now)
-	require.NoError(t, err)
-
-	lock := &redislock.Lock{
-		Client:       client,
-		Key:          "{ns1}:sidekiq-queue-pull:low",
-		ID:           uuid.NewString(),
-		At:           time.Now(),
-		ExpireInSec:  30,
-		MaxAcquirers: 1,
-	}
-	acquired, err := lock.Acquire()
-	require.NoError(t, err)
-	require.True(t, acquired)
-
-	err = q.Pull(&PullOptions{
-		Namespace:        "{ns1}",
-		SidekiqNamespace: "{ns1}",
-		SidekiqQueue:     "low",
-	})
-	require.NoError(t, err)
 }
 
 func TestSidekiqQueueDequeueDeletedJob(t *testing.T) {


### PR DESCRIPTION
1. rename the main list to inprogress list, and track it in zset for recovery
2. process that inprogress list with a single goroutine (extend with heartbeat)
3. if that goroutine drains the list eventually, remove the inprogress list from zset
4. for recovery, if inprogress list's heartbeat is old, let another goroutine to process it.