### PR TITLE
TWEAK: define prometheus buckets

### DIFF
--- a/middleware/prometheus/metrics.go
+++ b/middleware/prometheus/metrics.go
@@ -13,6 +13,7 @@ var (
 			Namespace: "work",
 			Name:      "job_execution_time_seconds",
 			Help:      "Time for a job to finish successfully",
+			Buckets:   []float64{1, 10, 60},
 		},
 		[]string{"namespace", "queue"},
 	)
@@ -61,6 +62,7 @@ var (
 			Namespace: "work",
 			Name:      "job_latency_seconds",
 			Help:      "Processing delay from oldest ready job",
+			Buckets:   []float64{1, 10, 60},
 		},
 		[]string{"namespace", "queue"},
 	)

--- a/middleware/prometheus/metrics_test.go
+++ b/middleware/prometheus/metrics_test.go
@@ -40,6 +40,7 @@ func TestHandleFuncMetrics(t *testing.T) {
 	promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).
 		ServeHTTP(r, httptest.NewRequest("GET", "/metrics", nil))
 
+	t.Log(r.Body.String())
 	for _, m := range []string{
 		`work_job_executed_total{`,
 		`work_job_execution_time_seconds_bucket{`,
@@ -76,6 +77,7 @@ func TestEnqueueFuncMetrics(t *testing.T) {
 	promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).
 		ServeHTTP(r, httptest.NewRequest("GET", "/metrics", nil))
 
+	t.Log(r.Body.String())
 	for _, m := range []string{
 		`work_job_enqueued_total{`,
 	} {
@@ -113,6 +115,7 @@ func TestExportWorkerMetrics(t *testing.T) {
 	promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).
 		ServeHTTP(r, httptest.NewRequest("GET", "/metrics", nil))
 
+	t.Log(r.Body.String())
 	for _, m := range []string{
 		`job_ready{`,
 		`job_scheduled{`,


### PR DESCRIPTION
https://github.com/prometheus/client_golang/blob/d03abf3a31c973a5bc2c2dc698fb41b661a0f0c5/prometheus/histogram.go#L264C5-L264C15

The default value has too many buckets